### PR TITLE
add: GVMクラス内にgetBPM()メソッドを追加 fix: tapTempo()メソッド内でstatic変数を呼び出す時にクラス名を明示

### DIFF
--- a/lib/p5.gvm.js
+++ b/lib/p5.gvm.js
@@ -46,6 +46,14 @@ class GVM {
     }
 
     /**
+     * 現在のBPM値を取得する
+     * @returns {number} 現在のBPM値
+     */
+    getBPM() {
+        return this.bpm_;
+    }
+
+    /**
      * 現在の拍カウントを取得（キャッシュ機能付き）
      * @returns {number} 現在の拍カウント
      */
@@ -125,15 +133,17 @@ class GVM {
         const currentTimeMs = millis();
 
         this.recordTimes_.push(currentTimeMs);
-        this.recordTimes_ = this.recordTimes_.filter(time => currentTimeMs - time <= MAX_TIME_DIFF);
+        // class GVM の static プロパティとして使うので GVM.MAX_TIME_DIFF とする
+        this.recordTimes_ = this.recordTimes_.filter(time => currentTimeMs - time <= GVM.MAX_TIME_DIFF);
 
-        if (this.recordTimes_.length >= RECORD_INTERVAL) {
+        // こちらも GVM.RECORD_INTERVAL と修正
+        if (this.recordTimes_.length >= GVM.RECORD_INTERVAL) {
             let totalDiffMs = 0;
-            for (let i = 1; i < RECORD_INTERVAL; i++) {
+            for (let i = 1; i < GVM.RECORD_INTERVAL; i++) {
                 totalDiffMs += this.recordTimes_[this.recordTimes_.length - i] - this.recordTimes_[this.recordTimes_.length - i - 1];
             }
 
-            const averageDiffMs = totalDiffMs / (RECORD_INTERVAL - 1);
+            const averageDiffMs = totalDiffMs / (GVM.RECORD_INTERVAL - 1);
             const bpm = 60000 / averageDiffMs;
 
             this.setBPM(bpm);


### PR DESCRIPTION
- GVMクラス内のBPMの値を取り出せるようにするためgetBPM()メソッドを追加しました。
- tapTempo()メソッド内でGVMクラスのstatic変数を呼び出す際に、クラス名を明示していないためエラーが発生しており、tapTempo()メソッドが動作していなかったため、明示するように書き換えました。